### PR TITLE
Remove global overwrite of jQuery in deparam.js

### DIFF
--- a/lib/deparam.js
+++ b/lib/deparam.js
@@ -2,7 +2,7 @@
   jQuery deparam is an extraction of the deparam method from Ben Alman's jQuery BBQ
   http://benalman.com/projects/jquery-bbq-plugin/
 */
-$ = jquery = require("jquery");
+var $ = require("jquery");
 $.deparam = function (params, coerce) {
 var obj = {},
 	coerce_types = { 'true': !0, 'false': !1, 'null': null };


### PR DESCRIPTION
deparam.js now globally overwrites jQuery, in my case with an older version that I actually require. This change fixes the scoping.
