### PR TITLE
Filter the allowed values for long Unicode codepoint escape sequences.

### DIFF
--- a/lib/flint.js
+++ b/lib/flint.js
@@ -3974,7 +3974,8 @@
 		      //unicode escape sequences (which the sparql spec considers part of the pre-processing of sparql queries)
 		      //are marked as invalid. We have little choice (other than adding a layer of complixity) than to modify the grammar accordingly
 		      //however, for now only allow these escape sequences in literals (where actually, this should be allows in e.g. prefixes as well)
-			var unicode = '(\\\\u' + HEX +'{4}|\\\\U' + HEX + '{8})';
+			var hex4 = HEX + '{4}'
+			var unicode = '(\\\\u' + hex4 +'|\\\\U00(10|0' + HEX + ')'+ hex4 + ')';
 	
 			var STRING_LITERAL1 = "'(([^\\x27\\x5C\\x0A\\x0D])|"+ECHAR+"|" + unicode + ")*'";
 			var STRING_LITERAL2 = '"(([^\\x22\\x5C\\x0A\\x0D])|'+ECHAR+'|' + unicode + ')*"';


### PR DESCRIPTION
I have tested this locally and it seems to work as one would hope to restrict the long Unicode codepoint escape sequences to the range U+0 to U+10FFFF.
