### PR TITLE
Use protocol relative URL to retrieve prefixes

### DIFF
--- a/src/autocompleters/prefixes.js
+++ b/src/autocompleters/prefixes.js
@@ -18,7 +18,7 @@ module.exports = function(yasqe, completerName) {
 			return module.exports.isValidCompletionPosition(yasqe);
 		},
 		get: function(token, callback) {
-			$.get("http://prefix.cc/popular/all.file.json", function(data) {
+			$.get("//prefix.cc/popular/all.file.json", function(data) {
 				var prefixArray = [];
 				for (var prefix in data) {
 					if (prefix == "bif")


### PR DESCRIPTION
Use a protocol relative URL to get prefixes to avoid 'Mixed content' errors in the browser when hosting YASGUI over HTTPS.
