### PR TITLE
Check for apostrophe instead of prime

### DIFF
--- a/lib/grammar/tokenizer.js
+++ b/lib/grammar/tokenizer.js
@@ -7,7 +7,7 @@ CodeMirror.defineMode("sparql11", function(config, parserConfig) {
 	var grammar = require('./_tokenizer-table.js');
 	var ll1_table = grammar.table;
 
-	var IRI_REF = '<[^<>\"\'\|\{\}\^\\\x00-\x20]*>';
+	var IRI_REF = '<[^<>\"`\|\{\}\^\\\x00-\x20]*>';
 	/*
 	 * PN_CHARS_BASE =
 	 * '[A-Z]|[a-z]|[\\u00C0-\\u00D6]|[\\u00D8-\\u00F6]|[\\u00F8-\\u02FF]|[\\u0370-\\u037D]|[\\u037F-\\u1FFF]|[\\u200C-\\u200D]|[\\u2070-\\u218F]|[\\u2C00-\\u2FEF]|[\\u3001-\\uD7FF]|[\\uF900-\\uFDCF]|[\\uFDF0-\\uFFFD]|[\\u10000-\\uEFFFF]';


### PR DESCRIPTION
Hi,

Working on the following issue in Apache Jena: https://issues.apache.org/jira/browse/JENA-1072

For a bit of context, the following query:

```
ASK {
<http://en.wikipedia.org/wiki/Good_Love_(Meli'sa_Morgan_album)> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Document> .
}
```

Is marked as invalid, as in the following screen shot.

![screenshot_2016-10-09_20-50-46](https://cloud.githubusercontent.com/assets/304786/19219354/38d0679c-8e6d-11e6-9069-acbb63e0edaf.png)

I believe the cause for this issue is that the regular expression in used in YASQE is using a prime (single quote) instead of an apostrophe, as in https://www.w3.org/TR/sparql11-query/#rIRIREF

i.e., while the SPARQL 1.1 specification has iriref as _'<' ([^<>"{}|^`]-[#x00-#x20])\* '>'_, YASQE is converting that into the following regex _'<[^<>\"\'|{}^\\x00-\x20]*>'_.

This pull request addresses just the prime vs. apostrophe, and seems to fix the issue in the editor with the same query. However, I think there may be other differences in the regex and the spec value.

![screenshot_2016-10-09_22-02-00](https://cloud.githubusercontent.com/assets/304786/19219366/ba4ab872-8e6d-11e6-86f6-4fd558821cc8.png)

It was super easy to check out and play with YASQE in development mode, thanks for such a super library and for making it easier for other developers to play with it :-)

Thanks
Bruno
