### PR TITLE
Separate language strings. Fixes #111.

### DIFF
--- a/src/autocompleters/autocompleterBase.js
+++ b/src/autocompleters/autocompleterBase.js
@@ -228,7 +228,7 @@ module.exports = function(YASQE, yasqe) {
             completionNotifications[completer.name] = $("<div class='completionNotification'></div>");
           completionNotifications[completer.name]
             .show()
-            .text("Press CTRL - <spacebar> to autocomplete")
+            .text(yasqe.options.language.autocomplete.trigger)
             .appendTo($(yasqe.getWrapperElement()));
         }
       },

--- a/src/autocompleters/utils.js
+++ b/src/autocompleters/utils.js
@@ -52,7 +52,10 @@ var postprocessResourceTokenForCompletion = function(yasqe, token, suggestedStri
 var reqProtocol = window.location.protocol.indexOf("http") === 0 ? "//" : "http://";
 var fetchFromLov = function(yasqe, completer, token, callback) {
   if (!token || !token.string || token.string.trim().length == 0) {
-    yasqe.autocompleters.notifications.getEl(completer).empty().append("Nothing to autocomplete yet!");
+    yasqe.autocompleters.notifications
+      .getEl(completer)
+      .empty()
+      .append(yasqe.options.language.autocomplete.nothing);
     return false;
   }
   var maxResults = 50;
@@ -93,20 +96,25 @@ var fetchFromLov = function(yasqe, completer, token, callback) {
         if (results.length > 0) {
           yasqe.autocompleters.notifications.hide(yasqe, completer);
         } else {
-          yasqe.autocompleters.notifications.getEl(completer).text("0 matches found...");
+          yasqe.autocompleters.notifications
+            .getEl(completer)
+            .text(yasqe.options.language.autocomplete.zeroMatches);
         }
         callback(results);
         // requests done! Don't call this function again
       }
     }).fail(function(jqXHR, textStatus, errorThrown) {
-      yasqe.autocompleters.notifications.getEl(completer).empty().append("Failed fetching suggestions..");
+      yasqe.autocompleters.notifications
+        .getEl(completer)
+        .empty()
+        .append(yasqe.options.language.autocomplete.failedSuggestions);
     });
   };
   //if notification bar is there, show a loader
   yasqe.autocompleters.notifications
     .getEl(completer)
     .empty()
-    .append($("<span>Fetchting autocompletions &nbsp;</span>"))
+    .append($("<span>" + yasqe.options.language.autocomplete.fetching + "&nbsp;</span>"))
     .append($(yutils.svg.getElement(require("../imgs.js").loader)).addClass("notificationLoader"));
   doRequests();
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -31,6 +31,23 @@ YASQE.defaults = $.extend(true, {}, YASQE.defaults, {
     console.warn("Could not store in localstorage. Skipping..", e);
   },
   /**
+   * Default locale
+   */
+  language: {
+    invalidLine: "This line is invalid. Expected:",
+    setFullScreen: "Set editor to full screen",
+    setSmallScreen: "Set editor to normal size",
+    shareQuery: "Share your query",
+    shorten: "Shorten",
+    autocomplete: {
+      failedSuggestions: "Failed fetching suggestions..",
+      fetching: "Fetching autocompletions",
+      nothing: "Nothing to autocomplete yet!",
+      trigger: "Press CTRL - <space> to autocomplete",
+      zeroMatches: "0 matches found..."
+    }
+  },
+  /**
 	 * Extra shortcut keys. Check the CodeMirror manual on how to add your own
 	 *
 	 * @property extraKeys

--- a/src/main.js
+++ b/src/main.js
@@ -373,7 +373,7 @@ var checkSyntax = function(yasqe, deepcheck) {
               "<strong style='text-decoration:underline'>" + $("<div/>").text(expected).html() + "</strong>"
             );
           });
-          return "This line is invalid. Expected: " + expectedEncoded.join(", ");
+          return yasqe.options.language.invalidLine + expectedEncoded.join(", ");
         });
       }
       warningEl.style.marginTop = "2px";
@@ -506,7 +506,7 @@ root.drawButtons = function(yasqe) {
         popup.empty().append($("<div>", { class: "inputWrapper" }).append($input));
         if (yasqe.options.createShortLink) {
           popup.addClass("enableShort");
-          $("<button>Shorten</button>")
+          $("<button>" + yasqe.options.language.shorten + "</button>")
             .addClass("yasqe_btn yasqe_btn-sm yasqe_btn-primary")
             .click(function() {
               $(this).parent().find("button").attr("disabled", "disabled");
@@ -535,7 +535,7 @@ root.drawButtons = function(yasqe) {
         $input.focus();
       })
       .addClass("yasqe_share")
-      .attr("title", "Share your query")
+      .attr("title", yasqe.options.language.shareQuery)
       .appendTo(yasqe.buttons);
   }
 
@@ -549,7 +549,7 @@ root.drawButtons = function(yasqe) {
     .append(
       $(yutils.svg.getElement(imgs.fullscreen))
         .addClass("yasqe_fullscreenBtn")
-        .attr("title", "Set editor full screen")
+        .attr("title", yasqe.options.language.setFullScreen)
         .click(function() {
           yasqe.setOption("fullScreen", true);
         })
@@ -557,7 +557,7 @@ root.drawButtons = function(yasqe) {
     .append(
       $(yutils.svg.getElement(imgs.smallscreen))
         .addClass("yasqe_smallscreenBtn")
-        .attr("title", "Set editor to normal size")
+        .attr("title", yasqe.options.language.setSmallScreen)
         .click(function() {
           yasqe.setOption("fullScreen", false);
         })


### PR DESCRIPTION
I've separated the language strings to defaults.js, so that they are exposed as `yasqe.options.language` and can be thus overwritten by different locale in the `YASQE` constructor. I've also fixed a couple of typos, such as "Fetchting autocompletions" in autocompletes.utils.js.

This is just a proposal of how localization can be introduced in YASQE. Please advise if there is another preferred way to do so.