### PR TITLE
Fix transparent background of the popup to share query link.

### DIFF
--- a/src/scss/buttons.scss
+++ b/src/scss/buttons.scss
@@ -75,7 +75,7 @@
 				position:absolute;
 				padding: 4px;
 				margin-left: 0px;
-				// background-color: ;
+				background-color: #fff;
 				border: 1px solid #e3e3e3;
 				border-radius: 4px;
 				-webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.05);


### PR DESCRIPTION
The popup for sharing the query link has transparent background, as can be seen here:

<img width="621" alt="screen shot 2017-06-19 at 15 40 56" src="https://user-images.githubusercontent.com/198642/27289136-30087416-5509-11e7-8174-ee5e212a0fb7.png">

I changed the popup's background to white.
