### PR TITLE
Fix TypeError caused by incorrect JQuery call

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -354,7 +354,7 @@ var checkSyntax = function(yasqe, deepcheck) {
     if (state.OK == false) {
       if (!yasqe.options.syntaxErrorCheck) {
         //the library we use already marks everything as being an error. Overwrite this class attribute.
-        $(yasqe.getWrapperElement).find(".sp-error").css("color", "black");
+        $(yasqe.getWrapperElement()).find(".sp-error").css("color", "black");
         //we don't want to gutter error, so return
         return;
       }


### PR DESCRIPTION
Fixes an uncaught exception which happens when a user tries to perform edits and `syntaxErrorCheck` is `false`.

Full stack trace:
```
Uncaught TypeError: Cannot read property 'wrapper' of undefined
    at HTMLDocument.getWrapperElement (codemirror.js:5358)
    at fire (jquery.js:3187)
    at Object.add [as done] (jquery.js:3246)
    at jQuery.fn.init.jQuery.fn.ready (jquery.js:3496)
    at new jQuery.fn.init (jquery.js:2927)
    at jQuery (jquery.js:75)
    at checkSyntax (main.js:357)
    at main.js:252
    at codemirror.js:8247
    at fireCallbacksForOps (codemirror.js:3047)
```