### PR TITLE
Set svg-image height to inherit

### DIFF
--- a/src/scss/buttons.scss
+++ b/src/scss/buttons.scss
@@ -118,6 +118,7 @@
 			margin-left: 10px;
 			.svgImg {
 				display:block;
+				height: inherit;
 			}
 			.loader {
 			  @include spinner($queryButtonWidth, $queryButtonHeight);


### PR DESCRIPTION
The play button within YASQE in IE11 was incorrectly positioned. By forcing the height to be inherited it was fixed again