### PR TITLE
Add Comunica to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ publishers.  Here is a partial list:
     browser
   * [**Trifid**](https://github.com/zazuko/trifid)
     light-weight Linked Data Server and Proxy
+  * [**Comunica widget**](https://github.com/comunica/jQuery-Widget.js)
+    Web-based Linked Data query engine
+    ([demo](http://query.linkeddatafragments.org/)
   
 ### Data Publishers
 

--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
         <li><a href="https://github.com/jiemakel/visu" target="_blank">Visu</a> <small>(<a href="http://demo.seco.tkk.fi/visu/" target="_blank">demo</a>)</small>, the first library to extend YASR with Google Chart functionality</li>
         <li><a href="https://github.com/Data2Semantics/brwsr" target="_blank">Brwsr</a>, a Linked Data browser</li>
         <li><a href="https://github.com/zazuko/trifid" target="_blank">Trifid</a>, a lightweight Linked Data server and proxy</li>
+        <li><a href="https://github.com/comunica/jQuery-Widget.js" target="_blank">Comunica widget</a> <small>(<a href="http://query.linkeddatafragments.org/" target="_blank">demo</a>)</small>, a widget for the Web-based Linked Data query engine <a href="https://github.com/comunica/comunica" target="_blank">Comunica</a></li>
         </ul>
         <p>Publishers are using  as well, such as
         <a href="http://www.healthdata.gov/sparql/" target="_blank">HealthData.gov</a>


### PR DESCRIPTION
As originally discussed in https://github.com/LinkedDataFragments/jQuery-Widget.js/issues/4, the jQuery widget for our new Comunica engine now finally uses YASQE as its SPARQL editor, as can be seen here: http://query.linkeddatafragments.org/

This PR adds Comunica to the list of users of this tool.