### PR TITLE
Avoid infinite loops when the line is incorrect

### DIFF
--- a/src/prefixFold.js
+++ b/src/prefixFold.js
@@ -29,7 +29,8 @@ function findFirstPrefix(cm, line, ch, lineText) {
     if (pass == 1 && found < ch) break;
     var tokenType = cm.getTokenTypeAt(CodeMirror.Pos(line, found + 1));
     if (!/^(comment|string)/.test(tokenType)) return found + 1;
-    at = found - 1;
+    if (!/(comment)/.test(tokenType)) break;
+    
     //Could not find a prefix, no use looping any further. Probably invalid query
     if (at === pass) break;
   }


### PR DESCRIPTION
This seems to solves #140 however we need clean tests for that function, it is not clear why it is written that way and what kind of cases it is trying to solve. Having a non conditional loop requires that we make absolutely sure that it can exit the loop. 

Maybe in the mean time we need to add a counter that is initialized with the length of the line and make it spit a warning if it gets there. 
At least that would not make it crash and we would have debug information on why it crashed.