### PR TITLE
Changed the definition of propertyListNotEmpty.

### DIFF
--- a/lib/grammar/sparql11-grammar.pl
+++ b/lib/grammar/sparql11-grammar.pl
@@ -346,7 +346,7 @@ propertyList ==> [propertyListNotEmpty].
 propertyList ==> [].
 %[77]
 propertyListNotEmpty ==> 
-	[verb,objectList,*([';',?([verb,objectList])])].
+	[verbPath or verbSimple,objectList,*([';',?([verbPath or verbSimple,objectList])])].
 % storeProperty is a dummy for side-effect of remembering property
 storeProperty==>[].
 %[78]


### PR DESCRIPTION
The new definition uses 'verbPath or verbSimple' instead of 'verb'. Note that 'verb' is also defined in 'verbPath or verbSimple'. The need for change came from a query that included nested bnode syntax and a property path sequence '/'; As soon as the prop.path sequence sign is inserted when more than one bnode syntax is present, the specific query line where the property sequence path resides is marked as invalid. However, the query runs and evaluates just fine.
verbPath handles property paths, including sequences, hence why the change fixes this issue. 

NOTE: 'verb' is only used to define propertyListNotEmpty. Should you decide that the change is appropriate, you might consider omitting 'verb' overall, as it will be obsolete.

Itso Ivanov
